### PR TITLE
Add PHP 5.5/5.6 to travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: php
 php:
   - 5.4
+  - 5.5
+  - 5.6
 
 before_script:
   - composer install


### PR DESCRIPTION
I was able to successfully run the phpunit tests locally on both 5.5 and 5.6, so this PR should be safe to merge without breaking the travis build.