### PR TITLE
Support base_host parameter in RepositorySolo

### DIFF
--- a/src/Resources/doc/cookbook/example_advanced.md
+++ b/src/Resources/doc/cookbook/example_advanced.md
@@ -142,6 +142,7 @@ concerto:
             arguments:
                 - @your_soloist_repository
                 - forRequest
+                - "%base_host%"
 ```
 ```yml
 # services.yml

--- a/src/Solo/RepositorySolo.php
+++ b/src/Solo/RepositorySolo.php
@@ -22,6 +22,9 @@ class RepositorySolo implements SoloInterface
 
     /** @var string */
     protected $repoMethodName;
+    
+     /** @var string */
++    protected $baseHost;
 
     /**
      * Constructs a RepositorySolo.
@@ -29,10 +32,11 @@ class RepositorySolo implements SoloInterface
      * @param EntityRepository $repo
      * @param string           $repoMethodName
      */
-    public function __construct(EntityRepository $repo, $repoMethodName)
+    public function __construct(EntityRepository $repo, $repoMethodName, $baseHost)
     {
         $this->repository = $repo;
         $this->repoMethodName = $repoMethodName;
+        $this->baseHost = $baseHost;
     }
 
     /**
@@ -48,7 +52,7 @@ class RepositorySolo implements SoloInterface
      */
     public function getSoloist(Request $request)
     {
-        $ret = $this->repository->{$this->repoMethodName}($request);
+        $ret = $this->repository->{$this->repoMethodName}($request, $this->baseHost);
 
         if(is_a( $ret, 'Ctrl\Bundle\ConcertoBundle\Model\Soloist' ) ) {
             return $ret;


### PR DESCRIPTION
When using RepositorySolo strategy, if the Soloist class is based on a parameter like the subdomain, it's needed to pass an additional config parameter "base_host". In this PR this additional parameter is supported and was added to the doc.